### PR TITLE
ci: reduce Actions waste — follow-up: bare-runner env for versioning, git-root fix for doc generator

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -29,6 +29,16 @@ jobs:
   versioning:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Real environment variables, not a .env file: settings.py resolves the
+    # .env file at BASE_DIR (= apps/), so a repo-root .env is never read on a
+    # bare runner. Docker only worked because `docker run --env-file` injected
+    # these as process env — job-level env reproduces that.
+    env:
+      DEBUG: 'True'
+      SECRET_KEY: github-actions-key
+      DATABASE_URL: sqlite:///db.sqlite3
+      AI_API_KEY: ${{ secrets.AI_API_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout repository
@@ -36,16 +46,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
-
-      - name: Create environment file
-        run: |
-          {
-            echo "DEBUG=True"
-            echo "SECRET_KEY=github-actions-key"
-            echo "DATABASE_URL=sqlite:///db.sqlite3"
-            echo "AI_API_KEY=${{ secrets.AI_API_KEY }}"
-            echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
-          } > .env
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/apps/core/services/doc_service.py
+++ b/apps/core/services/doc_service.py
@@ -94,7 +94,10 @@ class ChangelogService:
         Migrated from auto_doc_generator.py
         """
         repo_path = repo_path or settings.BASE_DIR
-        repo = Repo(repo_path)
+        # BASE_DIR is <root>/apps, which is not itself a git repository —
+        # search parent directories so the enclosing repo root is found
+        # (works both in Docker at /app/apps and on bare runners).
+        repo = Repo(repo_path, search_parent_directories=True)
         head_commit = repo.head.commit
         diff_data = head_commit.diff(None, create_patch=True)
 


### PR DESCRIPTION
Follow-up to #92 (merged before post-merge verification completed). The first push to main after the merge surfaced two issues, both verified locally before this PR:

## 1. `versioning.yml` regression — .env never read on the bare runner
The merge-commit run failed with `OperationalError: failed to resolve host 'db'`. Root cause: `apps/githubai/settings.py` resolves the `.env` file at `BASE_DIR`, which is `<root>/apps` — the repo-root `.env` the workflow writes was never read. The old Docker flow only worked because `docker run --env-file .env` injected those values as real process environment variables.

**Fix:** drop the `.env`-file step and set the same values as job-level `env:` (which is exactly what `--env-file` was providing). Verified locally: `manage.py migrate --run-syncdb` boots against sqlite with only those env vars set.

## 2. `auto-doc-generator.yml` — next latent bug surfaced
Good news first: the #92 env fix worked — the run got past `Provider configuration validation failed for: openai` for the first time in 8 months. It then failed at the next layer: `git.exc.InvalidGitRepositoryError: /app/apps`. `ChangelogService.generate_from_commit` calls `Repo(settings.BASE_DIR)` and `BASE_DIR` is `apps/`, which is not a git repository in any environment.

**Fix:** `Repo(repo_path, search_parent_directories=True)` so GitPython walks up to the enclosing repo root (`/app` in Docker, the checkout root on bare runners). Verified locally: the old call raises `InvalidGitRepositoryError`, the new one resolves the repo root and reads HEAD.

`actionlint` passes on all workflows. Pre-existing test-suite drift documented in #92 is unchanged and still needs its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)