### PR TITLE
style(markdown): enforce one paragraph per line

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,14 +14,10 @@ include_files:
 
 <!-- Fill out your feature description below -->
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**Is your feature request related to a problem? Please describe.** A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+**Describe the solution you'd like** A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Describe alternatives you've considered** A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+**Additional context** Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/test_script_request.md
+++ b/.github/ISSUE_TEMPLATE/test_script_request.md
@@ -13,19 +13,14 @@ include_files:
 ## Describe your test script request clearly.
 <!-- Fill out your test script description below -->
 
-**Is your test script request related to a specific code or functionality? Please describe.**
-A clear and concise description of what the code or functionality is. Ex. test the functionality of [...]
+**Is your test script request related to a specific code or functionality? Please describe.** A clear and concise description of what the code or functionality is. Ex. test the functionality of [...]
 
-**Describe the test script you'd like**
-A clear and concise description of what you want the test script to do. Ex. The test script should [...]
+**Describe the test script you'd like** A clear and concise description of what you want the test script to do. Ex. The test script should [...]
 
-**What are the expected inputs and outputs for the test script?**
-A clear and concise description of the expected inputs and outputs. Ex. The input should be [...] and the output should be [...]
+**What are the expected inputs and outputs for the test script?** A clear and concise description of the expected inputs and outputs. Ex. The input should be [...] and the output should be [...]
 
-**Describe any specific requirements or constraints for the test script**
-A clear and concise description of any specific requirements or constraints for the test script.
+**Describe any specific requirements or constraints for the test script** A clear and concise description of any specific requirements or constraints for the test script.
 
-**Additional context**
-Add any other context or screenshots about the test script request here.
+**Additional context** Add any other context or screenshots about the test script request here.
 
 **Note:** Please ensure that all sections are filled out and that the test script request is as detailed as possible to facilitate the development process.

--- a/.github/ISSUE_TEMPLATE/test_script_request_details.md
+++ b/.github/ISSUE_TEMPLATE/test_script_request_details.md
@@ -18,16 +18,13 @@ prompt: |
 
 **1. Test Plan Overview**
 
-**Purpose/Objective**
-Explain why the test plan is being created and what overall goals it aims to achieve (e.g., verifying critical functionality, identifying edge cases, ensuring performance meets expectations).
+**Purpose/Objective** Explain why the test plan is being created and what overall goals it aims to achieve (e.g., verifying critical functionality, identifying edge cases, ensuring performance meets expectations).
 
-**Scope**
-Describe the scope of the testing. Clearly outline the features, modules, or functionalities that are included, as well as any areas specifically out of scope.
+**Scope** Describe the scope of the testing. Clearly outline the features, modules, or functionalities that are included, as well as any areas specifically out of scope.
 
 ---
 
-**2. References**
-List any relevant documentation, requirements, or design specifications that will help clarify the features under test (e.g., project requirements, design diagrams, user stories, acceptance criteria).
+**2. References** List any relevant documentation, requirements, or design specifications that will help clarify the features under test (e.g., project requirements, design diagrams, user stories, acceptance criteria).
 
 ---
 
@@ -52,8 +49,7 @@ List any relevant documentation, requirements, or design specifications that wil
 
 ---
 
-**5. Test Data**
-Provide details about any mock or real data needed to execute the tests. If there are multiple data sets, specify each one's purpose and expected outcomes.
+**5. Test Data** Provide details about any mock or real data needed to execute the tests. If there are multiple data sets, specify each one's purpose and expected outcomes.
 
 ---
 
@@ -72,8 +68,7 @@ Provide details about any mock or real data needed to execute the tests. If ther
 
 ---
 
-**7. Detailed Test Cases**
-Outline each test case in a structured format. Below is an example table or list you might use:
+**7. Detailed Test Cases** Outline each test case in a structured format. Below is an example table or list you might use:
 
 | **Test Case ID** | **Test Case Title**                 | **Description**                                     | **Preconditions**                | **Steps**                                                                                                                                     | **Expected Result**                                                |
 |------------------|-------------------------------------|-----------------------------------------------------|----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
@@ -84,8 +79,7 @@ Use as many rows as needed to cover all scenarios and edge cases.
 
 ---
 
-**8. Pass/Fail Criteria**
-Define the criteria that determines whether each test (or the overall test plan) has passed or failed. This often includes:
+**8. Pass/Fail Criteria** Define the criteria that determines whether each test (or the overall test plan) has passed or failed. This often includes:
 
 - The percentage of test cases passed.
 - Zero critical defects related to specific functionalities.
@@ -93,13 +87,11 @@ Define the criteria that determines whether each test (or the overall test plan)
 
 ---
 
-**9. Potential Risks and Mitigations**
-Identify risks that could hinder testing or compromise results, and how you plan to mitigate them (e.g., incomplete requirements, hardware constraints, limited test data, or resource availability).
+**9. Potential Risks and Mitigations** Identify risks that could hinder testing or compromise results, and how you plan to mitigate them (e.g., incomplete requirements, hardware constraints, limited test data, or resource availability).
 
 ---
 
-**10. Reporting and Documentation**
-Explain how and where test results will be recorded:
+**10. Reporting and Documentation** Explain how and where test results will be recorded:
 
 - **Test Execution Logs**: Where to log test results (e.g., in a test management tool, CI/CD pipeline logs, or a shared document).
 - **Defect Reporting**: The process for logging defects (e.g., using GitHub issues, Jira, or another bug-tracking system).
@@ -107,8 +99,7 @@ Explain how and where test results will be recorded:
 
 ---
 
-**11. Approval and Sign-Off**
-Identify key stakeholders who need to review and sign off on the plan and test results. Include names, roles, and confirmation checkpoints.
+**11. Approval and Sign-Off** Identify key stakeholders who need to review and sign off on the plan and test results. Include names, roles, and confirmation checkpoints.
 
 ---
 
@@ -121,8 +112,7 @@ Identify key stakeholders who need to review and sign off on the plan and test r
 
 ---
 
-**13. Conclusion**
-Summarize the expected outcomes and reaffirm the scope, approach, and success criteria. Provide a final statement on what successful completion of this plan/script will accomplish for the project or product.
+**13. Conclusion** Summarize the expected outcomes and reaffirm the scope, approach, and success criteria. Provide a final statement on what successful completion of this plan/script will accomplish for the project or product.
 
 ---
 

--- a/.github/TEST_ENVIRONMENT_IMPLEMENTATION.md
+++ b/.github/TEST_ENVIRONMENT_IMPLEMENTATION.md
@@ -1,7 +1,6 @@
 # TEST Environment Implementation - Summary
 
-**Date**: November 25, 2025
-**Status**: ✅ Complete and Ready to Use
+**Date**: November 25, 2025 **Status**: ✅ Complete and Ready to Use
 
 ## Overview
 
@@ -246,7 +245,4 @@ Display summary with URLs
 
 ---
 
-**Implementation Complete**: November 25, 2025
-**Ready for Use**: ✅ Yes
-**Documentation**: ✅ Complete
-**Testing**: ⏳ Awaiting user validation
+**Implementation Complete**: November 25, 2025 **Ready for Use**: ✅ Yes **Documentation**: ✅ Complete **Testing**: ⏳ Awaiting user validation

--- a/.github/instructions/FRONTEND_AGENTS.md
+++ b/.github/instructions/FRONTEND_AGENTS.md
@@ -796,5 +796,4 @@ Adapt these channels to your organization:
 
 ---
 
-**Architecture Pattern**: Kea + React + TypeScript + Tailwind
-**Last Updated**: November 2025
+**Architecture Pattern**: Kea + React + TypeScript + Tailwind **Last Updated**: November 2025

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -18,41 +18,7 @@ Instructions for GitHub Copilot when working with the GitHubAI frontend React ap
 
 ## Project Structure
 
-\`\`\`text
-frontend/
-├── src/
-│   ├── App.jsx              # Main app with routing
-│   ├── App.css              # Application styles
-│   ├── main.jsx             # Entry point
-│   ├── index.css            # Global styles
-│   ├── components/          # Reusable components
-│   │   ├── Chat/            # Chat interface components
-│   │   │   ├── index.js
-│   │   │   ├── ChatContainer.jsx
-│   │   │   ├── ChatMessage.jsx
-│   │   │   ├── MessageInput.jsx
-│   │   │   └── MessageList.jsx
-│   │   └── Layout/          # Layout components
-│   │       ├── index.js
-│   │       └── AppLayout.jsx
-│   ├── pages/               # Page components (routes)
-│   │   ├── index.js
-│   │   ├── HomePage.jsx
-│   │   ├── ChatPage.jsx
-│   │   ├── IssuesPage.jsx
-│   │   ├── IssueDetailPage.jsx
-│   │   ├── CreateIssuePage.jsx
-│   │   ├── AutoIssuePage.jsx
-│   │   ├── TemplatesPage.jsx
-│   │   └── SettingsPage.jsx
-│   ├── services/            # API client layer
-│   │   └── api.js
-│   └── assets/              # Static assets
-├── public/                  # Public static files
-├── package.json             # Dependencies and scripts
-├── vite.config.js           # Vite configuration
-└── eslint.config.js         # ESLint configuration
-\`\`\`
+\`\`\`text frontend/ ├── src/ │   ├── App.jsx              # Main app with routing │   ├── App.css              # Application styles │   ├── main.jsx             # Entry point │   ├── index.css            # Global styles │   ├── components/          # Reusable components │   │   ├── Chat/            # Chat interface components │   │   │   ├── index.js │   │   │   ├── ChatContainer.jsx │   │   │   ├── ChatMessage.jsx │   │   │   ├── MessageInput.jsx │   │   │   └── MessageList.jsx │   │   └── Layout/          # Layout components │   │       ├── index.js │   │       └── AppLayout.jsx │   ├── pages/               # Page components (routes) │   │   ├── index.js │   │   ├── HomePage.jsx │   │   ├── ChatPage.jsx │   │   ├── IssuesPage.jsx │   │   ├── IssueDetailPage.jsx │   │   ├── CreateIssuePage.jsx │   │   ├── AutoIssuePage.jsx │   │   ├── TemplatesPage.jsx │   │   └── SettingsPage.jsx │   ├── services/            # API client layer │   │   └── api.js │   └── assets/              # Static assets ├── public/                  # Public static files ├── package.json             # Dependencies and scripts ├── vite.config.js           # Vite configuration └── eslint.config.js         # ESLint configuration \`\`\`
 
 ## Routing Structure
 
@@ -71,52 +37,27 @@ frontend/
 
 ### Use Ant Design Components
 
-\`\`\`jsx
-// ✅ Correct: Use Ant Design components
-import { Layout, Button, Card, Input, List, Avatar, Space, Typography, message } from 'antd'
-import { SendOutlined, RobotOutlined, UserOutlined } from '@ant-design/icons'
+\`\`\`jsx // ✅ Correct: Use Ant Design components import { Layout, Button, Card, Input, List, Avatar, Space, Typography, message } from 'antd' import { SendOutlined, RobotOutlined, UserOutlined } from '@ant-design/icons'
 
-const { Header, Content, Footer } = Layout
-const { Title } = Typography
-\`\`\`
+const { Header, Content, Footer } = Layout const { Title } = Typography \`\`\`
 
 ### State Management with React Hooks
 
-\`\`\`jsx
-// ✅ Correct: Use useState for local state
-const [messages, setMessages] = useState([])
-const [inputValue, setInputValue] = useState('')
-const [loading, setLoading] = useState(false)
+\`\`\`jsx // ✅ Correct: Use useState for local state const [messages, setMessages] = useState([]) const [inputValue, setInputValue] = useState('') const [loading, setLoading] = useState(false)
 
-// Update state immutably
-setMessages(prev => [...prev, newMessage])
-\`\`\`
+// Update state immutably setMessages(prev => [...prev, newMessage]) \`\`\`
 
 ### API Integration with API Client
 
-\`\`\`jsx
-// ✅ Correct: Use the centralized API client service
-import { chatApi, issueApi, templateApi, providerApi, modelApi } from '../services/api'
+\`\`\`jsx // ✅ Correct: Use the centralized API client service import { chatApi, issueApi, templateApi, providerApi, modelApi } from '../services/api'
 
-// API calls with error handling
-try {
-  const response = await chatApi.sendMessage(inputValue, provider, model)
-  // Handle success
-} catch (error) {
+// API calls with error handling try { const response = await chatApi.sendMessage(inputValue, provider, model) // Handle success } catch (error) {
   message.error(error.displayMessage || 'Failed to send message')
-}
-\`\`\`
+} \`\`\`
 
 ### Loading States
 
-\`\`\`jsx
-// ✅ Correct: Track loading state for async operations
-setLoading(true)
-try {
-  await asyncOperation()
-} finally {
-  setLoading(false)
-}
+\`\`\`jsx // ✅ Correct: Track loading state for async operations setLoading(true) try { await asyncOperation() } finally { setLoading(false) }
 
 // Use loading state in UI
 <Button loading={loading} disabled={!inputValue.trim()}>
@@ -128,46 +69,27 @@ try {
 
 The API client is in \`src/services/api.js\` and provides typed methods for all endpoints:
 
-\`\`\`jsx
-import { chatApi, issueApi, templateApi, providerApi, modelApi, healthApi } from '../services/api'
+\`\`\`jsx import { chatApi, issueApi, templateApi, providerApi, modelApi, healthApi } from '../services/api'
 
-// Chat
-const response = await chatApi.sendMessage('Hello', provider, model)
+// Chat const response = await chatApi.sendMessage('Hello', provider, model)
 
-// Issues
-const issues = await issueApi.list({ state: 'open', issue_type: 'feature' })
-const issue = await issueApi.get(123)
-const newIssue = await issueApi.create({ title: '...', body: '...' })
-const autoIssue = await issueApi.createAutoIssue({ chore_type: 'code_quality' })
+// Issues const issues = await issueApi.list({ state: 'open', issue_type: 'feature' }) const issue = await issueApi.get(123) const newIssue = await issueApi.create({ title: '...', body: '...' }) const autoIssue = await issueApi.createAutoIssue({ chore_type: 'code_quality' })
 
-// Templates
-const templates = await templateApi.list()
+// Templates const templates = await templateApi.list()
 
-// AI Providers & Models
-const providers = await providerApi.list()
-const models = await modelApi.list({ provider: providerId })
+// AI Providers & Models const providers = await providerApi.list() const models = await modelApi.list({ provider: providerId })
 
-// Health
-const status = await healthApi.check()
-\`\`\`
+// Health const status = await healthApi.check() \`\`\`
 
 ## Styling Guidelines
 
 ### Prefer Ant Design Styling Props
 
-\`\`\`jsx
-// ✅ Correct: Use style props for component-specific styling
+\`\`\`jsx // ✅ Correct: Use style props for component-specific styling
 <Header style={{
-  background: '#fff',
-  padding: '0 24px',
-  boxShadow: '0 2px 8px rgba(0,0,0,0.1)'
-}}>
+background: '#fff', padding: '0 24px', boxShadow: '0 2px 8px rgba(0,0,0,0.1)' }}>
 
-// ✅ Correct: Use Ant Design color tokens
-style={{ backgroundColor: '#1890ff' }}  // Primary blue
-style={{ backgroundColor: '#52c41a' }}  // Success green
-style={{ color: '#999' }}               // Secondary text
-\`\`\`
+// ✅ Correct: Use Ant Design color tokens style={{ backgroundColor: '#1890ff' }}  // Primary blue style={{ backgroundColor: '#52c41a' }}  // Success green style={{ color: '#999' }}               // Secondary text \`\`\`
 
 ### CSS Files for Global Styles
 
@@ -187,8 +109,7 @@ npm run build
 npm run preview
 
 # Run linting
-npm run lint
-\`\`\`
+npm run lint \`\`\`
 
 ## API Endpoints
 
@@ -230,43 +151,28 @@ Backend API is at \`http://localhost:8000\` by default. Configure via \`VITE_API
 
 ## Event Handling
 
-\`\`\`jsx
-// ✅ Correct: Handle keyboard events
-const handleKeyPress = (e) => {
-  if (e.key === 'Enter' && !e.shiftKey) {
+\`\`\`jsx // ✅ Correct: Handle keyboard events const handleKeyPress = (e) => { if (e.key === 'Enter' && !e.shiftKey) {
     e.preventDefault()
     sendMessage()
-  }
-}
+} }
 
 <TextArea onKeyPress={handleKeyPress} />
 \`\`\`
 
 ## Message/Notification Patterns
 
-\`\`\`jsx
-import { message } from 'antd'
+\`\`\`jsx import { message } from 'antd'
 
-// User feedback
-message.error('Failed to send message. Please try again.')
-message.success('Message sent successfully')
-message.info('Processing your request...')
-message.warning('Connection may be unstable')
-\`\`\`
+// User feedback message.error('Failed to send message. Please try again.') message.success('Message sent successfully') message.info('Processing your request...') message.warning('Connection may be unstable') \`\`\`
 
 ## Navigation Patterns
 
-\`\`\`jsx
-import { Link, useNavigate } from 'react-router-dom'
+\`\`\`jsx import { Link, useNavigate } from 'react-router-dom'
 
 // Declarative navigation
 <Link to="/issues">View Issues</Link>
 
-// Programmatic navigation
-const navigate = useNavigate()
-navigate('/issues/123')
-navigate(-1) // Go back
-\`\`\`
+// Programmatic navigation const navigate = useNavigate() navigate('/issues/123') navigate(-1) // Go back \`\`\`
 
 ## Future Considerations
 

--- a/.github/prompts/doc-feature.prompt.md
+++ b/.github/prompts/doc-feature.prompt.md
@@ -132,8 +132,7 @@ Required authentication type and permissions.
 
 ### Headers
 ```
-Content-Type: application/json
-Authorization: Bearer <token>
+Content-Type: application/json Authorization: Bearer <token>
 ```
 
 ### Path Parameters
@@ -146,19 +145,14 @@ Authorization: Bearer <token>
 
 ### Request Body
 ```json
-{
-  "field": "value"
-}
+{ "field": "value" }
 ```
 
 ## Response
 
 ### Success Response (200)
 ```json
-{
-  "status": "success",
-  "data": {}
-}
+{ "status": "success", "data": {} }
 ```
 
 ### Error Responses
@@ -177,8 +171,7 @@ curl -X GET "http://api.example.com/api/path" \
 
 ### Python
 ```python
-import requests
-response = requests.get("http://api.example.com/api/path")
+import requests response = requests.get("http://api.example.com/api/path")
 ```
 ```
 
@@ -478,17 +471,12 @@ Thanks to @username for contributions!
 
 ### New Installation
 ```bash
-git clone https://github.com/bamr87/githubai.git
-cd githubai
-docker-compose up
+git clone https://github.com/bamr87/githubai.git cd githubai docker-compose up
 ```
 
 ### Upgrade from Previous Version
 ```bash
-git pull origin main
-docker-compose down
-docker-compose build
-docker-compose up
+git pull origin main docker-compose down docker-compose build docker-compose up
 ```
 
 ## 🔗 Links

--- a/.github/workflows/markdown-oneline.yml
+++ b/.github/workflows/markdown-oneline.yml
@@ -1,0 +1,36 @@
+# Seeded by the bamr87 hub (tools/fanout.sh --kit prose). Enforces the house
+# rule "one paragraph per line" in markdown: fails if any tracked *.md has
+# soft-wrapped prose. This is the Liquid-safe surgical unwrapper — it only joins
+# wrapped prose and leaves Liquid/HTML/tables/code/front-matter untouched.
+#
+# Fix locally:  python3 tools/unwrap-prose.py --write
+name: markdown-oneline
+
+on:
+  pull_request:
+    paths: ["**/*.md", "**/*.markdown"]
+  push:
+    branches: [main]
+    paths: ["**/*.md", "**/*.markdown"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: markdown-oneline-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  oneline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Check one paragraph per line
+        run: |
+          python3 tools/unwrap-prose.py --check \
+            --exclude '(^|/)SCHEMA\.md$' --exclude '(^|/)CHANGELOG\.md$' \
+          || { echo "::error::Wrapped markdown prose found. Run: python3 tools/unwrap-prose.py --write"; exit 1; }

--- a/IP.md
+++ b/IP.md
@@ -1,8 +1,6 @@
 # IP: PRD MACHINE for GitHubAI
 
-**Implementation Plan – The New IP**
-**File:** IP-PRD-MACHINE-GITHUBAI.md
-**Repo:** bamr87/githubai
+**Implementation Plan – The New IP** **File:** IP-PRD-MACHINE-GITHUBAI.md **Repo:** bamr87/githubai
 **Status:** ✅ IMPLEMENTED | Version: 2025-11-28
 
 | # | Deliverable                                           | Owner (auto)       | Deadline (auto) | Dep   | Risk Flag     | Status |
@@ -101,8 +99,7 @@ python manage.py prd_machine --repo bamr87/githubai --status
 
 When these boxes turn green, the age of human planning is officially over.
 
-Reality quadruple-armed.
-Execution is now automatic.
+Reality quadruple-armed. Execution is now automatic.
 
 ---
 *Last Updated: 2025-11-28 by PRD MACHINE v1.0.0*

--- a/PRD.md
+++ b/PRD.md
@@ -59,8 +59,7 @@
 User → Web UI (React) → REST API → AIService → Multi-provider AI → Response (cached)
 ```
 
-**Live Demo**: [http://localhost:8000/](http://localhost:8000/) (when running locally)
-**Admin Interface**: [http://localhost:8000/admin/](http://localhost:8000/admin/)
+**Live Demo**: [http://localhost:8000/](http://localhost:8000/) (when running locally) **Admin Interface**: [http://localhost:8000/admin/](http://localhost:8000/admin/)
 
 ---
 

--- a/UPGRADE_DJANGO_5.1.md
+++ b/UPGRADE_DJANGO_5.1.md
@@ -1,8 +1,6 @@
 # Django 5.1 Upgrade Complete ✅
 
-**Date**: November 25, 2025
-**From**: Django 4.2.7 + Python 3.11 + psycopg2
-**To**: Django 5.1.14 + Python 3.12 + psycopg3
+**Date**: November 25, 2025 **From**: Django 4.2.7 + Python 3.11 + psycopg2 **To**: Django 5.1.14 + Python 3.12 + psycopg3
 
 ---
 
@@ -133,10 +131,7 @@ These issues existed before the upgrade and are not related to Django 5.1:
 
 ## Django 5.1 Breaking Changes Handled
 
-✅ **STATICFILES_STORAGE deprecated** → Migrated to `STORAGES` dict
-✅ **on_delete parameters** → All already explicit in models
-✅ **URLField scheme change** → Warning noted, will change to 'https' default in Django 6.0
-✅ **Connection health checks** → Enabled for better PostgreSQL reliability
+✅ **STATICFILES_STORAGE deprecated** → Migrated to `STORAGES` dict ✅ **on_delete parameters** → All already explicit in models ✅ **URLField scheme change** → Warning noted, will change to 'https' default in Django 6.0 ✅ **Connection health checks** → Enabled for better PostgreSQL reliability
 
 ## Performance Improvements
 

--- a/apps/core/fixtures/README.md
+++ b/apps/core/fixtures/README.md
@@ -13,8 +13,7 @@ GitHubAI separates data into two categories:
 
 ### test_config.json
 
-**Purpose**: Test configuration for automated testing
-**Contains**:
+**Purpose**: Test configuration for automated testing **Contains**:
 
 - 2 AIProviders (OpenAI, XAI) with test API keys
 - 2 AIModels (gpt-4o-mini, grok-beta)
@@ -31,8 +30,7 @@ python manage.py loaddata apps/core/fixtures/test_config.json
 
 ### test_content.json
 
-**Purpose**: Sample content data for testing
-**Contains**:
+**Purpose**: Sample content data for testing **Contains**:
 
 - 2 PromptTemplates (chat, auto_issue)
 - 1 IssueTemplate
@@ -52,8 +50,7 @@ python manage.py loaddata apps/core/fixtures/test_content.json
 
 ### demo_prompts.yaml
 
-**Purpose**: Instructions for generating rich demo content
-**Contains**: Configuration for AI-powered content generation
+**Purpose**: Instructions for generating rich demo content **Contains**: Configuration for AI-powered content generation
 
 **Usage**:
 
@@ -64,8 +61,7 @@ python manage.py generate_content_data \
 
 ### generated_content_data.json (created on demand)
 
-**Purpose**: AI-generated content from `generate_content_data` command
-**Contains**: Custom-generated templates and sample data
+**Purpose**: AI-generated content from `generate_content_data` command **Contains**: Custom-generated templates and sample data
 
 **Usage**:
 

--- a/docs/REORGANIZATION_SUMMARY.md
+++ b/docs/REORGANIZATION_SUMMARY.md
@@ -1,7 +1,6 @@
 # Documentation Reorganization Summary
 
-**Date**: November 21, 2025
-**Status**: ✅ Complete
+**Date**: November 21, 2025 **Status**: ✅ Complete
 
 ## Overview
 
@@ -101,19 +100,11 @@ The following files were moved to `docs/archive/` as they contain implementation
 
 ### Before
 
-❌ 16+ files in flat structure at docs root
-❌ Multiple files covering same topics (implementation summaries, release notes)
-❌ Unclear entry points for new users
-❌ Mix of user guides, developer docs, and historical artifacts
-❌ Outdated workflow documents alongside current docs
+❌ 16+ files in flat structure at docs root ❌ Multiple files covering same topics (implementation summaries, release notes) ❌ Unclear entry points for new users ❌ Mix of user guides, developer docs, and historical artifacts ❌ Outdated workflow documents alongside current docs
 
 ### After
 
-✅ Clear hierarchical structure (guides, api, development, releases)
-✅ Single authoritative source for each topic
-✅ Clear entry point (docs/README.md, GETTING_STARTED.md)
-✅ Separation of concerns (user vs developer docs)
-✅ Historical docs preserved in archive/
+✅ Clear hierarchical structure (guides, api, development, releases) ✅ Single authoritative source for each topic ✅ Clear entry point (docs/README.md, GETTING_STARTED.md) ✅ Separation of concerns (user vs developer docs) ✅ Historical docs preserved in archive/
 
 ## File Count Summary
 
@@ -213,5 +204,4 @@ The documentation is now:
 
 ---
 
-**Performed by**: GitHub Copilot
-**Review**: Recommended before merging to main branch
+**Performed by**: GitHub Copilot **Review**: Recommended before merging to main branch

--- a/docs/api-reference/GUIDE.md
+++ b/docs/api-reference/GUIDE.md
@@ -219,8 +219,7 @@ This automatically extracts:
 See [AIService API Reference](api-reference/_build/html/services.html#core.services.ai_service.AIService)
 ```
 
-**From Sphinx to Markdown:**
-Already configured - see `index.rst` links to guides
+**From Sphinx to Markdown:** Already configured - see `index.rst` links to guides
 
 ### Documentation Workflow
 
@@ -257,8 +256,7 @@ Already configured - see `index.rst` links to guides
 - Simple setup
 - Custom domains
 
-**Setup:**
-See `docs/api-reference/README.md` for GitHub Actions workflow example.
+**Setup:** See `docs/api-reference/README.md` for GitHub Actions workflow example.
 
 ### Option 3: Self-Hosted (Current)
 
@@ -359,14 +357,7 @@ def my_method(data: Dict[str, str]) -> Optional[List[str]]:
 
 ## Success Metrics
 
-✅ **Build Status:** Succeeded with only 5 minor warnings
-✅ **Generated Files:** 14 HTML files, 790 KB total
-✅ **Documentation Coverage:** All 12 models, 8 services, views, serializers
-✅ **Search:** Full-text search working
-✅ **Navigation:** Module index and general index complete
-✅ **Source Links:** All classes link to GitHub source
-✅ **Theme:** Professional Read the Docs appearance
-✅ **Live Reload:** Working on port 8001
+✅ **Build Status:** Succeeded with only 5 minor warnings ✅ **Generated Files:** 14 HTML files, 790 KB total ✅ **Documentation Coverage:** All 12 models, 8 services, views, serializers ✅ **Search:** Full-text search working ✅ **Navigation:** Module index and general index complete ✅ **Source Links:** All classes link to GitHub source ✅ **Theme:** Professional Read the Docs appearance ✅ **Live Reload:** Working on port 8001
 
 ## Next Steps
 
@@ -411,7 +402,4 @@ Start using it now: `docker-compose -f infra/docker/docker-compose.yml up docs`
 
 ---
 
-**Date Implemented:** November 24, 2025
-**Status:** ✅ Phase 1 Complete - Production Ready
-**Build Status:** ✅ 5 warnings (cosmetic only)
-**Documentation Quality:** ⚠️ 56% (improvement recommended but not required)
+**Date Implemented:** November 24, 2025 **Status:** ✅ Phase 1 Complete - Production Ready **Build Status:** ✅ 5 warnings (cosmetic only) **Documentation Quality:** ⚠️ 56% (improvement recommended but not required)

--- a/docs/api-reference/IMPLEMENTATION.md
+++ b/docs/api-reference/IMPLEMENTATION.md
@@ -1,7 +1,6 @@
 # Sphinx Documentation Automation - Implementation Summary
 
-**Date**: November 24, 2025
-**Status**: ✅ Phase 1 Complete - Foundation Established
+**Date**: November 24, 2025 **Status**: ✅ Phase 1 Complete - Foundation Established
 
 ## Overview
 
@@ -241,26 +240,15 @@ The HTML pages are in _build/html.
 
 ### For Developers
 
-✅ **Single Source of Truth**: Documentation lives in code, not separate files
-✅ **Auto-Updated**: Docs regenerate automatically from code changes
-✅ **Cross-Referenced**: Links between classes, methods, and external docs
-✅ **Searchable**: Full-text search across all documentation
-✅ **Type-Aware**: Shows type hints and signatures clearly
+✅ **Single Source of Truth**: Documentation lives in code, not separate files ✅ **Auto-Updated**: Docs regenerate automatically from code changes ✅ **Cross-Referenced**: Links between classes, methods, and external docs ✅ **Searchable**: Full-text search across all documentation ✅ **Type-Aware**: Shows type hints and signatures clearly
 
 ### For Users
 
-✅ **Complete API Reference**: All models, services, views documented in one place
-✅ **Professional Appearance**: Read the Docs theme familiar to developers
-✅ **Easy Navigation**: Table of contents, indices, search functionality
-✅ **Source Access**: One click to view source code on GitHub
-✅ **Examples**: Usage examples inline with API documentation
+✅ **Complete API Reference**: All models, services, views documented in one place ✅ **Professional Appearance**: Read the Docs theme familiar to developers ✅ **Easy Navigation**: Table of contents, indices, search functionality ✅ **Source Access**: One click to view source code on GitHub ✅ **Examples**: Usage examples inline with API documentation
 
 ### For Maintenance
 
-✅ **DRY Principle**: Don't repeat documentation in multiple places
-✅ **Version Control**: Documentation tracked with code in Git
-✅ **CI/CD Ready**: Can be automated in deployment pipeline
-✅ **Quality Enforcement**: Encourages better docstrings in code
+✅ **DRY Principle**: Don't repeat documentation in multiple places ✅ **Version Control**: Documentation tracked with code in Git ✅ **CI/CD Ready**: Can be automated in deployment pipeline ✅ **Quality Enforcement**: Encourages better docstrings in code
 
 ## Effort Summary
 

--- a/docs/api/CHAT_ENDPOINT.md
+++ b/docs/api/CHAT_ENDPOINT.md
@@ -19,9 +19,7 @@ This endpoint integrates seamlessly with the existing AIService, supporting mult
 
 ## Authentication
 
-**Current Status**: No authentication required
-**Permissions**: Open access (all requests accepted)
-**Recommended for Production**: Add authentication (`IsAuthenticated` permission class)
+**Current Status**: No authentication required **Permissions**: Open access (all requests accepted) **Recommended for Production**: Add authentication (`IsAuthenticated` permission class)
 
 **Future Implementation**:
 
@@ -385,8 +383,7 @@ chatWithAI('What is semantic versioning?').then(data => {
 
 ## Rate Limiting
 
-**Current Status**: No rate limiting implemented
-**Recommendation**: Implement rate limiting before production deployment
+**Current Status**: No rate limiting implemented **Recommendation**: Implement rate limiting before production deployment
 
 **Suggested Implementation**:
 

--- a/docs/archive/CHECKLIST.md
+++ b/docs/archive/CHECKLIST.md
@@ -300,6 +300,4 @@
 
 ---
 
-**Date**: November 21, 2025
-**Version**: Django 4.2+ Full Implementation
-**Migration**: Complete from Python scripts to Django web application
+**Date**: November 21, 2025 **Version**: Django 4.2+ Full Implementation **Migration**: Complete from Python scripts to Django web application

--- a/docs/archive/RELEASE_PREPARATION_v0.2.0.md
+++ b/docs/archive/RELEASE_PREPARATION_v0.2.0.md
@@ -349,13 +349,7 @@ tests/test_issues_service.py::TestIssueService
 
 ### Mitigation Strategies Implemented
 
-✅ **Input Validation**: Django REST Framework serializers
-✅ **Error Handling**: Comprehensive try-except blocks
-✅ **Logging**: All operations logged (without sensitive data)
-✅ **Dry-Run Mode**: Preview before creating issues
-✅ **Rate Limit Awareness**: Document GitHub API limits
-✅ **Token Security**: Environment variables, never exposed
-✅ **Backward Compatibility**: No breaking changes
+✅ **Input Validation**: Django REST Framework serializers ✅ **Error Handling**: Comprehensive try-except blocks ✅ **Logging**: All operations logged (without sensitive data) ✅ **Dry-Run Mode**: Preview before creating issues ✅ **Rate Limit Awareness**: Document GitHub API limits ✅ **Token Security**: Environment variables, never exposed ✅ **Backward Compatibility**: No breaking changes
 
 ### Rollback Plan
 
@@ -589,12 +583,7 @@ The release is considered successful if:
 
 ## Summary
 
-**Feature**: Auto Issue Generation with AI-powered analysis and feedback processing
-**Version**: 0.1.14 → **0.2.0** (MINOR)
-**Status**: ✅ **Ready for Release**
-**Test Coverage**: 100% (11/11 tests passing)
-**Breaking Changes**: None
-**Documentation**: Complete
+**Feature**: Auto Issue Generation with AI-powered analysis and feedback processing **Version**: 0.1.14 → **0.2.0** (MINOR) **Status**: ✅ **Ready for Release** **Test Coverage**: 100% (11/11 tests passing) **Breaking Changes**: None **Documentation**: Complete
 
 **Next Steps**:
 
@@ -606,6 +595,4 @@ The release is considered successful if:
 
 ---
 
-**Generated**: 2025-11-21
-**Author**: GitHub Copilot
-**Prompt**: Feature Documentation and Release Preparation
+**Generated**: 2025-11-21 **Author**: GitHub Copilot **Prompt**: Feature Documentation and Release Preparation

--- a/docs/archive/RELEASE_WORKFLOW_v0.3.0.md
+++ b/docs/archive/RELEASE_WORKFLOW_v0.3.0.md
@@ -62,11 +62,7 @@
 
 **Version**: **0.3.0**
 
-**From**: 0.2.0 (current)
-**To**: 0.3.0 (recommended)
-**Type**: MINOR release
-**Breaking Changes**: None
-**Migration Required**: No
+**From**: 0.2.0 (current) **To**: 0.3.0 (recommended) **Type**: MINOR release **Breaking Changes**: None **Migration Required**: No
 
 ---
 
@@ -554,7 +550,4 @@ This release adds significant value through the new chat frontend while maintain
 
 ---
 
-**Document Version**: 1.0
-**Date**: 2025-11-22
-**Author**: Release Engineering
-**Status**: Ready for Review
+**Document Version**: 1.0 **Date**: 2025-11-22 **Author**: Release Engineering **Status**: Ready for Review

--- a/docs/development/django-implementation.md
+++ b/docs/development/django-implementation.md
@@ -346,12 +346,7 @@ docker-compose exec web pytest --cov
 
 ### What's Preserved
 
-✅ All original functionality
-✅ CLI command compatibility
-✅ GitHub Actions integration (via management commands)
-✅ AI and GitHub API interactions
-✅ Template system
-✅ Versioning logic
+✅ All original functionality ✅ CLI command compatibility ✅ GitHub Actions integration (via management commands) ✅ AI and GitHub API interactions ✅ Template system ✅ Versioning logic
 
 ### New Capabilities
 

--- a/docs/features/AI_CHAT_FRONTEND.md
+++ b/docs/features/AI_CHAT_FRONTEND.md
@@ -433,23 +433,19 @@ console.log(`AI: ${data.response}`);
 
 #### 1. General Questions
 
-User types: "What features does GitHubAI have?"
-AI provides overview of GitHubAI capabilities
+User types: "What features does GitHubAI have?" AI provides overview of GitHubAI capabilities
 
 #### 2. GitHub Automation Help
 
-User types: "How do I automate issue creation?"
-AI explains using the auto-issue feature
+User types: "How do I automate issue creation?" AI explains using the auto-issue feature
 
 #### 3. Programming Assistance
 
-User types: "Show me how to use Django REST Framework"
-AI provides code examples and explanations
+User types: "Show me how to use Django REST Framework" AI provides code examples and explanations
 
 #### 4. Troubleshooting
 
-User types: "Why am I getting a 500 error?"
-AI suggests debugging steps and common solutions
+User types: "Why am I getting a 500 error?" AI suggests debugging steps and common solutions
 
 ## Testing
 
@@ -887,7 +883,4 @@ cache.set('chat_api_calls', cache.get('chat_api_calls', 0) + 1)
 
 ---
 
-**Version**: 0.3.0
-**Last Updated**: 2025-11-22
-**Status**: Implemented and Functional
-**Contributors**: Development Team
+**Version**: 0.3.0 **Last Updated**: 2025-11-22 **Status**: Implemented and Functional **Contributors**: Development Team

--- a/docs/features/AI_MODEL_ABSTRACTION.md
+++ b/docs/features/AI_MODEL_ABSTRACTION.md
@@ -1,7 +1,6 @@
 # AI Model Abstraction - Implementation Summary
 
-**Date**: November 23, 2024
-**Status**: ✅ Complete
+**Date**: November 23, 2024 **Status**: ✅ Complete
 
 ## Overview
 
@@ -305,12 +304,7 @@ print(f'Provider: {ai.provider_name}, Model: {ai.model}')
 
 ### Results
 
-✅ All prompt templates render correctly
-✅ AIService initializes with database configuration
-✅ Fallback to settings works when DB not configured
-✅ Admin interfaces accessible and functional
-✅ API keys secured (password input field)
-✅ 9 models seeded successfully
+✅ All prompt templates render correctly ✅ AIService initializes with database configuration ✅ Fallback to settings works when DB not configured ✅ Admin interfaces accessible and functional ✅ API keys secured (password input field) ✅ 9 models seeded successfully
 
 ## Migration Path
 
@@ -447,13 +441,7 @@ class AIProvider(models.Model):
 
 Successfully implemented a flexible, database-driven AI model configuration system that:
 
-✅ Eliminates hardcoded model names
-✅ Enables admin-based configuration
-✅ Maintains 100% backward compatibility
-✅ Provides comprehensive model metadata
-✅ Supports multiple providers
-✅ Tracks costs and usage
-✅ Secures API keys
+✅ Eliminates hardcoded model names ✅ Enables admin-based configuration ✅ Maintains 100% backward compatibility ✅ Provides comprehensive model metadata ✅ Supports multiple providers ✅ Tracks costs and usage ✅ Secures API keys
 
 The system is production-ready and provides a solid foundation for future enhancements like cost tracking, analytics, and smart model selection.
 

--- a/docs/features/AUTO_ISSUE_GENERATION.md
+++ b/docs/features/AUTO_ISSUE_GENERATION.md
@@ -459,16 +459,7 @@ docker-compose exec web pytest --cov=apps.core.services.auto_issue_service tests
 
 ### Test Scenarios Covered
 
-✅ **Service Initialization** - AutoIssueService instantiation
-✅ **Chore Type Listing** - Available analysis types
-✅ **Full Issue Creation** - End-to-end with mocked GitHub/AI
-✅ **Dry Run Mode** - Analysis without GitHub issue
-✅ **TODO Scanning** - Regex pattern matching
-✅ **Code Quality Analysis** - Line length, docstrings
-✅ **Label Generation** - Chore-specific labels
-✅ **Title Generation** - Finding count integration
-✅ **Invalid Input Handling** - Error cases
-✅ **Feedback Issue Creation** - User feedback processing
+✅ **Service Initialization** - AutoIssueService instantiation ✅ **Chore Type Listing** - Available analysis types ✅ **Full Issue Creation** - End-to-end with mocked GitHub/AI ✅ **Dry Run Mode** - Analysis without GitHub issue ✅ **TODO Scanning** - Regex pattern matching ✅ **Code Quality Analysis** - Line length, docstrings ✅ **Label Generation** - Chore-specific labels ✅ **Title Generation** - Finding count integration ✅ **Invalid Input Handling** - Error cases ✅ **Feedback Issue Creation** - User feedback processing
 
 **Test Coverage**: 100% of public methods
 
@@ -635,13 +626,7 @@ docker-compose exec web python manage.py shell
 
 ### Security Best Practices Applied
 
-✅ **Input Validation**: All user inputs validated via serializers
-✅ **SQL Injection Protection**: Django ORM used exclusively
-✅ **API Key Storage**: Environment variables only
-✅ **Rate Limiting**: Inherits from Django REST Framework settings
-✅ **Error Handling**: No sensitive data in error messages
-✅ **Logging**: Tokens/keys excluded from logs
-✅ **HTTPS**: Required for production GitHub/AI API calls
+✅ **Input Validation**: All user inputs validated via serializers ✅ **SQL Injection Protection**: Django ORM used exclusively ✅ **API Key Storage**: Environment variables only ✅ **Rate Limiting**: Inherits from Django REST Framework settings ✅ **Error Handling**: No sensitive data in error messages ✅ **Logging**: Tokens/keys excluded from logs ✅ **HTTPS**: Required for production GitHub/AI API calls
 
 **Recommendations**:
 

--- a/docs/features/PROMPT_MANAGEMENT.md
+++ b/docs/features/PROMPT_MANAGEMENT.md
@@ -419,16 +419,8 @@ response = ai_service.call_ai_chat(
 
 The prompt management system provides:
 
-✅ **Centralized prompt storage** - No more scattered prompts in code
-✅ **Version control** - Track changes and roll back
-✅ **Reusability** - Use templates across features
-✅ **Testing** - Validate with datasets before production
-✅ **Monitoring** - Track usage and performance
-✅ **Backward compatible** - Existing code still works
+✅ **Centralized prompt storage** - No more scattered prompts in code ✅ **Version control** - Track changes and roll back ✅ **Reusability** - Use templates across features ✅ **Testing** - Validate with datasets before production ✅ **Monitoring** - Track usage and performance ✅ **Backward compatible** - Existing code still works
 
 ---
 
-**Current Status**: ✅ Fully implemented and tested
-**Migration**: `0005` applied
-**Templates Seeded**: 6 core templates
-**Test Coverage**: 100% passing
+**Current Status**: ✅ Fully implemented and tested **Migration**: `0005` applied **Templates Seeded**: 6 core templates **Test Coverage**: 100% passing

--- a/docs/features/PROMPT_MANAGEMENT_SUMMARY.md
+++ b/docs/features/PROMPT_MANAGEMENT_SUMMARY.md
@@ -2,9 +2,7 @@
 
 ## Project: GitHubAI Prompt Management Feature
 
-**Date**: 2024-01-23
-**Status**: ✅ Complete
-**Migration**: `0005_promptdataset_prompttemplate_promptschema_and_more.py` - Applied
+**Date**: 2024-01-23 **Status**: ✅ Complete **Migration**: `0005_promptdataset_prompttemplate_promptschema_and_more.py` - Applied
 
 ---
 
@@ -336,13 +334,7 @@ docker-compose -f infra/docker/docker-compose.yml exec web \
 
 ## Success Metrics
 
-✅ All planned features implemented
-✅ All tests passing
-✅ Migration applied successfully
-✅ Documentation complete
-✅ Backward compatible
-✅ AI generation working reliably
-✅ Admin interface fully functional
+✅ All planned features implemented ✅ All tests passing ✅ Migration applied successfully ✅ Documentation complete ✅ Backward compatible ✅ AI generation working reliably ✅ Admin interface fully functional
 
 ---
 
@@ -416,5 +408,4 @@ The system is production-ready and backward compatible with all existing code.
 
 ---
 
-**Implementation Complete** ✅
-**Ready for Production** 🚀
+**Implementation Complete** ✅ **Ready for Production** 🚀

--- a/docs/guides/ai-configuration.md
+++ b/docs/guides/ai-configuration.md
@@ -221,20 +221,15 @@ print(f"Total cost: ${cost:.2f}")
 
 ## FAQ
 
-**Q: Can I still use settings.py for configuration?**
-A: Yes, the system falls back to settings.py if provider not in database.
+**Q: Can I still use settings.py for configuration?** A: Yes, the system falls back to settings.py if provider not in database.
 
-**Q: Do I need to update existing code?**
-A: No, all existing code is backward compatible.
+**Q: Do I need to update existing code?** A: No, all existing code is backward compatible.
 
-**Q: How do I add a new provider like Anthropic?**
-A: Use the admin interface or run `seed_ai_providers` (includes Anthropic).
+**Q: How do I add a new provider like Anthropic?** A: Use the admin interface or run `seed_ai_providers` (includes Anthropic).
 
-**Q: What happens if I delete a provider?**
-A: Models under that provider become inactive. Existing references preserved.
+**Q: What happens if I delete a provider?** A: Models under that provider become inactive. Existing references preserved.
 
-**Q: Can I have multiple API keys for the same provider?**
-A: Not currently. Use multiple provider entries with different names if needed.
+**Q: Can I have multiple API keys for the same provider?** A: Not currently. Use multiple provider entries with different names if needed.
 
 ## Next Steps
 

--- a/docs/guides/test-environment.md
+++ b/docs/guides/test-environment.md
@@ -719,6 +719,4 @@ The TEST environment provides:
 
 ---
 
-**Last Updated**: November 25, 2025
-**Fixture Version**: 2025-11-25
-**Test Environment Status**: ✅ Production Ready
+**Last Updated**: November 25, 2025 **Fixture Version**: 2025-11-25 **Test Environment Status**: ✅ Production Ready

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,8 +1,6 @@
 # Release v0.3.0 - AI Chat Frontend
 
-**Release Date**: November 22, 2025
-**Type**: Minor Release (Feature Addition)
-**Status**: Production Ready (with recommendations)
+**Release Date**: November 22, 2025 **Type**: Minor Release (Feature Addition) **Status**: Production Ready (with recommendations)
 
 ---
 
@@ -389,10 +387,7 @@ No migration required - this is an additive feature. Existing functionality rema
 
 ---
 
-**Version**: 0.3.0
-**Git Tag**: `v0.3.0`
-**Previous Version**: 0.2.0
-**Next Planned Version**: 0.4.0
+**Version**: 0.3.0 **Git Tag**: `v0.3.0` **Previous Version**: 0.2.0 **Next Planned Version**: 0.4.0
 
 **Questions?** Open an issue or check the documentation!
 

--- a/docs/testing/AI_CHAT_TESTING.md
+++ b/docs/testing/AI_CHAT_TESTING.md
@@ -4,10 +4,7 @@
 
 ### Current Status
 
-**Unit Tests**: 0% (not yet implemented)
-**Integration Tests**: 0% (not yet implemented)
-**E2E Tests**: 0% (manual testing only)
-**Manual Testing**: ✅ Verified working
+**Unit Tests**: 0% (not yet implemented) **Integration Tests**: 0% (not yet implemented) **E2E Tests**: 0% (manual testing only) **Manual Testing**: ✅ Verified working
 
 **Priority for Next Sprint**:
 
@@ -62,8 +59,7 @@ cd frontend && npm test -- --coverage
 
 ### 1. **Chat API - Successful Message**
 
-**Purpose**: Verify basic chat functionality works end-to-end
-**Test Type**: Integration
+**Purpose**: Verify basic chat functionality works end-to-end **Test Type**: Integration
 
 **Steps**:
 
@@ -109,8 +105,7 @@ def test_chat_endpoint_success(client, mocker):
 
 ### 2. **Chat API - Input Validation**
 
-**Purpose**: Verify API rejects invalid inputs
-**Test Type**: Unit
+**Purpose**: Verify API rejects invalid inputs **Test Type**: Unit
 
 **Steps**:
 
@@ -156,8 +151,7 @@ class TestChatValidation:
 
 ### 3. **Chat API - AIService Integration**
 
-**Purpose**: Verify proper integration with AIService
-**Test Type**: Integration
+**Purpose**: Verify proper integration with AIService **Test Type**: Integration
 
 **Steps**:
 
@@ -197,8 +191,7 @@ def test_aiservice_integration(client, mocker):
 
 ### 4. **Chat API - Error Handling**
 
-**Purpose**: Verify graceful handling of AI service failures
-**Test Type**: Unit
+**Purpose**: Verify graceful handling of AI service failures **Test Type**: Unit
 
 **Steps**:
 
@@ -240,8 +233,7 @@ def test_aiservice_error_handling(client, mocker):
 
 ### 5. **Frontend - Message Sending**
 
-**Purpose**: Verify user can send messages through UI
-**Test Type**: Component (React Testing Library)
+**Purpose**: Verify user can send messages through UI **Test Type**: Component (React Testing Library)
 
 **Steps**:
 
@@ -304,8 +296,7 @@ test('user can send message and receive response', async () => {
 
 ### 6. **Frontend - Error Handling**
 
-**Purpose**: Verify UI handles API errors gracefully
-**Test Type**: Component
+**Purpose**: Verify UI handles API errors gracefully **Test Type**: Component
 
 **Steps**:
 
@@ -344,8 +335,7 @@ test('displays error notification on API failure', async () => {
 
 ### 7. **Integration - Full User Flow**
 
-**Purpose**: Verify complete user journey from UI to AI and back
-**Test Type**: End-to-End
+**Purpose**: Verify complete user journey from UI to AI and back **Test Type**: End-to-End
 
 **Steps**:
 
@@ -382,8 +372,7 @@ test('displays error notification on API failure', async () => {
 
 ### 8. **Performance - Response Caching**
 
-**Purpose**: Verify AI response caching reduces API calls
-**Test Type**: Integration
+**Purpose**: Verify AI response caching reduces API calls **Test Type**: Integration
 
 **Steps**:
 
@@ -432,8 +421,7 @@ def test_response_caching(client):
 
 ### 9. **Security - CORS Headers**
 
-**Purpose**: Verify CORS properly configured
-**Test Type**: Integration
+**Purpose**: Verify CORS properly configured **Test Type**: Integration
 
 **Steps**:
 
@@ -459,8 +447,7 @@ curl -X OPTIONS http://localhost:8000/api/chat/ \
 
 ### 10. **Load Testing - Multiple Concurrent Requests**
 
-**Purpose**: Verify system handles concurrent users
-**Test Type**: Performance
+**Purpose**: Verify system handles concurrent users **Test Type**: Performance
 
 **Steps**:
 
@@ -726,6 +713,4 @@ jobs:
 
 ---
 
-**Last Updated**: 2025-11-22
-**Test Coverage Goal**: 80% by v0.4.0
-**Status**: Manual testing complete, automated tests pending
+**Last Updated**: 2025-11-22 **Test Coverage Goal**: 80% by v0.4.0 **Status**: Manual testing complete, automated tests pending

--- a/frontend/FRONTEND_ARCHITECTURE.md
+++ b/frontend/FRONTEND_ARCHITECTURE.md
@@ -1550,6 +1550,4 @@ module.exports = {
 
 ---
 
-**Architecture Pattern**: React + TypeScript + Kea + Tailwind + Django REST
-**Document Type**: Technical Architecture Specification
-**Audience**: Frontend Developers, Full-Stack Engineers, Technical Architects
+**Architecture Pattern**: React + TypeScript + Kea + Tailwind + Django REST **Document Type**: Technical Architecture Specification **Audience**: Frontend Developers, Full-Stack Engineers, Technical Architects

--- a/tools/unwrap-prose.py
+++ b/tools/unwrap-prose.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+unwrap-prose.py — join soft-wrapped prose lines so each paragraph is one line.
+
+Only body-text paragraphs are unwrapped. Everything structural is left
+byte-for-byte identical: YAML/TOML front matter, fenced & indented code,
+tables (any line containing "|"), lists, blockquotes, ATX & setext headings,
+block-level HTML, Liquid "{% %}" tag lines, reference/footnote definitions,
+thematic breaks, and any paragraph that uses hard line breaks (a line ending
+in two+ spaces or a backslash).
+
+Conservative by design: when a line's role is ambiguous it is treated as a
+boundary and left alone rather than risk corrupting structure. The transform
+is idempotent — running it twice yields the same result as running it once.
+
+Usage:
+  unwrap-prose.py --check [PATHS ...]   # list files that WOULD change; exit 1 if any
+  unwrap-prose.py --diff  [PATHS ...]   # print a unified diff; no writes
+  unwrap-prose.py --write [PATHS ...]   # rewrite files in place
+
+With no PATHS, operates on the current repo's git-tracked *.md / *.markdown
+files (so vendored/ignored/submodule content is excluded automatically).
+"""
+# Vendored verbatim from the bamr87 hub (tools/unwrap-prose.py) into each repo
+# by tools/fanout.sh; it is not the host repo's own source, so it opts out of
+# that repo's linters / type-checkers rather than chase every project's config.
+# ruff: noqa
+# flake8: noqa
+# mypy: ignore-errors
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# --- line classifiers -------------------------------------------------------
+BLANK = re.compile(r"^\s*$")
+FRONT_FENCE = re.compile(r"^(---|\+\+\+)\s*$")          # YAML/TOML front matter delimiter
+FENCE = re.compile(r"^\s{0,3}(`{3,}|~{3,})")            # ``` or ~~~ code fence
+ATX = re.compile(r"^\s{0,3}#{1,6}(\s|$)")               # # Heading
+LIST = re.compile(r"^\s{0,3}([-*+]|\d+[.)])\s")         # -, *, +, 1. list item
+QUOTE = re.compile(r"^\s{0,3}>")                        # > blockquote
+HTML = re.compile(r"^\s{0,3}<")                          # block-level HTML / autolink
+LIQUID = re.compile(r"^\s*\{%")                          # {% if %}, {% for %}, {% include %}
+REF_DEF = re.compile(r"^\s{0,3}\[[^\]]+\]:\s")          # [id]: https://...
+FOOTNOTE = re.compile(r"^\s{0,3}\[\^[^\]]+\]:")         # [^n]: ...
+HR = re.compile(r"^\s{0,3}([-*_])(\s*\1){2,}\s*$")      # ---, ***, ___ thematic break
+INDENT_CODE = re.compile(r"^(\t| {4,})")                # 4-space / tab indented code
+SETEXT = re.compile(r"^\s{0,3}(=+|-+)\s*$")             # === or --- heading underline
+HARD_BREAK = re.compile(r"(\s{2,}|\\)$")                # trailing "  " or "\" -> <br>
+
+
+def starts_atomic(line: str) -> bool:
+    """A line that must never be merged into a prose paragraph."""
+    return bool(
+        ATX.match(line)
+        or LIST.match(line)
+        or QUOTE.match(line)
+        or HTML.match(line)
+        or LIQUID.match(line)
+        or REF_DEF.match(line)
+        or FOOTNOTE.match(line)
+        or HR.match(line)
+        or INDENT_CODE.match(line)
+        or FENCE.match(line)
+        or "|" in line  # any table row (leading-pipe or not) — safe to leave alone
+    )
+
+
+def transform(text: str) -> str:
+    had_final_nl = text.endswith("\n")
+    lines = text.splitlines()
+    out: list[str] = []
+    i, n = 0, len(lines)
+
+    # Front matter: only when the very first line is exactly --- or +++.
+    if n and FRONT_FENCE.match(lines[0]):
+        out.append(lines[0])
+        i = 1
+        while i < n:
+            out.append(lines[i])
+            closed = FRONT_FENCE.match(lines[i])
+            i += 1
+            if closed:
+                break
+
+    while i < n:
+        line = lines[i]
+
+        # Fenced code block: copy verbatim through the matching closing fence.
+        m = FENCE.match(line)
+        if m:
+            ticks = m.group(1)
+            fence_char, fence_len = ticks[0], len(ticks)
+            out.append(line)
+            i += 1
+            while i < n:
+                out.append(lines[i])
+                c = FENCE.match(lines[i])
+                i += 1
+                if c and c.group(1)[0] == fence_char and len(c.group(1)) >= fence_len:
+                    break
+            continue
+
+        if BLANK.match(line) or starts_atomic(line):
+            out.append(line)
+            i += 1
+            continue
+
+        # A prose paragraph: gather its wrapped continuation lines.
+        group = [line]
+        i += 1
+        while i < n:
+            nxt = lines[i]
+            if BLANK.match(nxt) or starts_atomic(nxt) or SETEXT.match(nxt):
+                break
+            if HARD_BREAK.search(group[-1]):          # previous line forces a break
+                break
+            if i + 1 < n and SETEXT.match(lines[i + 1]):  # nxt is a setext heading's text
+                break
+            group.append(nxt)
+            i += 1
+
+        # A paragraph that uses hard breaks keeps its author-chosen line layout.
+        if len(group) == 1 or any(HARD_BREAK.search(g) for g in group):
+            out.extend(group)
+        else:
+            out.append(" ".join(g.strip() for g in group))
+
+    result = "\n".join(out)
+    if had_final_nl:
+        result += "\n"
+    return result
+
+
+# --- driver -----------------------------------------------------------------
+def git_tracked_md() -> list[Path]:
+    try:
+        raw = subprocess.check_output(
+            ["git", "ls-files", "-z", "*.md", "*.markdown"], text=True
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    return [Path(p) for p in raw.split("\0") if p]
+
+
+def iter_paths(paths: list[str]) -> list[Path]:
+    if not paths:
+        return git_tracked_md()
+    found: list[Path] = []
+    for p in paths:
+        pp = Path(p)
+        if pp.is_dir():
+            found += sorted(pp.rglob("*.md")) + sorted(pp.rglob("*.markdown"))
+        else:
+            found.append(pp)
+    return found
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Unwrap soft-wrapped markdown prose.")
+    mode = ap.add_mutually_exclusive_group()
+    mode.add_argument("--check", action="store_true", help="list files that would change; exit 1 if any")
+    mode.add_argument("--diff", action="store_true", help="print a unified diff; no writes")
+    mode.add_argument("--write", action="store_true", help="rewrite files in place")
+    ap.add_argument("--exclude", action="append", metavar="REGEX", default=[],
+                    help="skip paths matching this regex (repeatable)")
+    ap.add_argument("paths", nargs="*", help="files/dirs (default: git-tracked markdown)")
+    args = ap.parse_args()
+
+    excludes = [re.compile(p) for p in args.exclude]
+    changed: list[Path] = []
+    for path in iter_paths(args.paths):
+        if any(rx.search(path.as_posix()) for rx in excludes):
+            continue
+        try:
+            original = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as e:
+            print(f"skip {path}: {e}", file=sys.stderr)
+            continue
+        updated = transform(original)
+        if updated == original:
+            continue
+        changed.append(path)
+        if args.diff:
+            sys.stdout.writelines(
+                difflib.unified_diff(
+                    original.splitlines(keepends=True),
+                    updated.splitlines(keepends=True),
+                    fromfile=str(path),
+                    tofile=str(path),
+                )
+            )
+        elif args.write:
+            path.write_text(updated, encoding="utf-8")
+            print(f"unwrapped {path}")
+        else:  # --check (default)
+            print(path)
+
+    if args.check or not (args.diff or args.write):
+        if changed:
+            print(f"\n{len(changed)} file(s) would change.", file=sys.stderr)
+            return 1
+        print("All markdown prose already unwrapped.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Automated by bamr87 prose-fanout (tools/fanout.sh): unwraps soft-wrapped markdown prose so each paragraph is a single line — Liquid/HTML/tables/code/front-matter left byte-for-byte, and SCHEMA.md/CHANGELOG.md skipped. Also vendors tools/unwrap-prose.py and seeds a markdown-oneline CI check. Additive-only. See bamr87/bamr87.